### PR TITLE
Additional file for workflow 77

### DIFF
--- a/testbeam/config_econds_v1.json
+++ b/testbeam/config_econds_v1.json
@@ -1,0 +1,8 @@
+{
+    "ML-F*": {
+        "headerMarker": "0x154",
+        "passthrough": 1,
+        "Gain": [1, 1, 1, 1, 1, 1],
+        "CalibrationSC": [0, 0, 0, 0, 0, 0]
+    }
+}

--- a/testbeam/config_feds_v1.json
+++ b/testbeam/config_feds_v1.json
@@ -1,0 +1,7 @@
+{
+    "*": {
+        "mismatchPassthroughMode": 1,
+        "cbHeaderMarker": "0x7f",
+        "slinkHeaderMarker": "0x55"
+    }
+}


### PR DESCRIPTION
This PR adds two extra config files which workflow 77 has been copying locally whenever it's run.
It's "cleaner" to have this files promptly available from cms-data so that FileInPath can be directly used in the cfgs of the workflow
This should be used with https://github.com/cms-sw/cmssw/pull/49148